### PR TITLE
Add helper functions for Assert for special cases

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -53,3 +53,7 @@ func AssertErrEqual(t Tester, expected error, got error) {
 func AssertErrNil(t Tester, got error) {
 	Assert(t, got == nil, "Expected error == nil, got: ", got)
 }
+
+func AssertErrNotNil(t Tester, got error) {
+	Assert(t, got != nil, "Expected error != nil, but got nil.")
+}

--- a/assert.go
+++ b/assert.go
@@ -45,3 +45,7 @@ func Assert(t Tester, b bool, message ...interface{}) {
 		t.FailNow()
 	}
 }
+
+func AssertErrEqual(t Tester, expected error, got error) {
+	Assert(t, got == expected, "Expected error ==", expected, ", got:", got)
+}

--- a/assert.go
+++ b/assert.go
@@ -49,3 +49,7 @@ func Assert(t Tester, b bool, message ...interface{}) {
 func AssertErrEqual(t Tester, expected error, got error) {
 	Assert(t, got == expected, "Expected error ==", expected, ", got:", got)
 }
+
+func AssertErrNil(t Tester, got error) {
+	Assert(t, got == nil, "Expected error == nil, got: ", got)
+}

--- a/tests_test.go
+++ b/tests_test.go
@@ -16,6 +16,7 @@
 package tests
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -46,6 +47,32 @@ func TestAssertFail(t *testing.T) {
 
 	test := &FakeTester{}
 	Assert(test, false)
+
+	if !test.Failed() {
+		t.Fail()
+	}
+}
+
+func TestAssertErrEqualPass(t *testing.T) {
+	test := &FakeTester{}
+
+	err1 := errors.New("error")
+	err2 := err1
+
+	AssertErrEqual(test, err1, err2)
+
+	if test.Failed() {
+		t.Fail()
+	}
+}
+
+func TestAssertErrEqualFail(t *testing.T) {
+	test := &FakeTester{}
+
+	err1 := errors.New("error 1")
+	err2 := errors.New("error 2")
+
+	AssertErrEqual(test, err1, err2)
 
 	if !test.Failed() {
 		t.Fail()

--- a/tests_test.go
+++ b/tests_test.go
@@ -104,6 +104,31 @@ func TestAssertErrNilFail(t *testing.T) {
 	}
 }
 
+func TestAssertErrNotNilPass(t *testing.T) {
+	test := &FakeTester{}
+
+	err := errors.New("error")
+
+	AssertErrNotNil(test, err)
+
+	if test.Failed() {
+		t.Fail()
+	}
+}
+
+func TestAssertErrNotNilFail(t *testing.T) {
+	test := &FakeTester{}
+
+	var err error
+	err = nil
+
+	AssertErrNotNil(test, err)
+
+	if !test.Failed() {
+		t.Fail()
+	}
+}
+
 func TestTempfile(t *testing.T) {
 	s1 := Tempfile()
 	Assert(t, strings.Contains(s1, "gounittest"))

--- a/tests_test.go
+++ b/tests_test.go
@@ -79,6 +79,31 @@ func TestAssertErrEqualFail(t *testing.T) {
 	}
 }
 
+func TestAssertErrNilPass(t *testing.T) {
+	test := &FakeTester{}
+
+	var err error
+	err = nil
+
+	AssertErrNil(test, err)
+
+	if test.Failed() {
+		t.Fail()
+	}
+}
+
+func TestAssertErrNilFail(t *testing.T) {
+	test := &FakeTester{}
+
+	err := errors.New("error")
+
+	AssertErrNil(test, err)
+
+	if !test.Failed() {
+		t.Fail()
+	}
+}
+
 func TestTempfile(t *testing.T) {
 	s1 := Tempfile()
 	Assert(t, strings.Contains(s1, "gounittest"))


### PR DESCRIPTION
* AssertErrEqual
* AssertErrNil
* AssertErrNotNil

This could be a starting point for reducing boilerplate code in the heketi test code.